### PR TITLE
Changing the base node image to lts-alpine, for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:lts-alpine
 
 LABEL maintainer="banksio"
 


### PR DESCRIPTION
This makes sure that remote-media always uses the newest node LTS version.